### PR TITLE
Use protocol relative URL's for requests to Google Fonts

### DIFF
--- a/iframe/banner.html
+++ b/iframe/banner.html
@@ -6,7 +6,7 @@
 	<!-- Styles -->
 	<meta charset="UTF-8"> 
 	<link rel="stylesheet" type="text/css" href="css/min/banner.min.css">
-	<link href='http://fonts.googleapis.com/css?family=Open+Sans:400,600' rel='stylesheet' type='text/css'>
+	<link href='//fonts.googleapis.com/css?family=Open+Sans:400,600' rel='stylesheet' type='text/css'>
 </head>
 
 <body>

--- a/iframe/modal.html
+++ b/iframe/modal.html
@@ -6,7 +6,7 @@
 	<!-- Styles -->
 	<meta charset="UTF-8"> 
 	<link rel="stylesheet" type="text/css" href="css/min/modal.min.css">
-	<link href='http://fonts.googleapis.com/css?family=Open+Sans:400,600' rel='stylesheet' type='text/css'>
+	<link href='//fonts.googleapis.com/css?family=Open+Sans:400,600' rel='stylesheet' type='text/css'>
 </head>
 
 <body>


### PR DESCRIPTION
The `http://` link to Google fonts causes the loading of the fonts to fail and a warning in the browser about insecure content. This pull request fixes it.
